### PR TITLE
Update Docker.rst

### DIFF
--- a/Gettingstarted/Docker.rst
+++ b/Gettingstarted/Docker.rst
@@ -33,7 +33,7 @@ Init the project with the following command :
 
 ::
 
-  docker run -it --rm -v /Users/famille/Desktop/analyzeG3/projects:/usr/src/exakat/projects exakat/exakat:latest exakat init -p sculpin -R https://github.com/sculpin/sculpin -git
+  docker run -it --rm -v /Users/famille/Desktop/analyzeG3/projects:/usr/src/exakat/projects exakat/exakat:latest init -p sculpin -R https://github.com/sculpin/sculpin -git
 
 This will create a 'projects/sculpin' folder, with various documents and folder. The most important folder being 'code', where the code of the project is fetched, an cached. See _Commands for more details about the `init` command.
 
@@ -44,7 +44,7 @@ After creating the project, an audit may be run from the same directory:
 
 :: 
 
-    docker run -it --rm -v /Users/famille/Desktop/analyzeG3/projects:/usr/src/exakat/projects exakat/exakat:dev exakat project -p sculpin 
+    docker run -it --rm -v /Users/famille/Desktop/analyzeG3/projects:/usr/src/exakat/projects exakat/exakat:latest project -p sculpin 
 
 This command runs the whole cycle : code loading, code audits and report building. 
 
@@ -59,7 +59,7 @@ After a first audit, use the `report` command. Here is an example with the `Uml`
 
 :: 
 
-    docker run -it --rm -v /Users/famille/Desktop/analyzeG3/projects:/usr/src/exakat/projects exakat/exakat:dev exakat report -p sculpin -format Uml 
+    docker run -it --rm -v /Users/famille/Desktop/analyzeG3/projects:/usr/src/exakat/projects exakat/exakat:latest report -p sculpin -format Uml 
     
 Reports may only be build if the analysis they depend on, were already processed.
 
@@ -67,7 +67,7 @@ In command line, use the `-format` option, multiple times if necessary.
 
 :: 
 
-    docker run -it --rm -v /Users/famille/Desktop/analyzeG3/projects:/usr/src/exakat/projects exakat/exakat:dev exakat project -p sculpin -format Uml 
+    docker run -it --rm -v /Users/famille/Desktop/analyzeG3/projects:/usr/src/exakat/projects exakat/exakat:latest project -p sculpin -format Uml 
 
 In config.ini, edit the `projects/sculpin/report/config.ini` file, and add the following lines : 
 
@@ -89,8 +89,8 @@ After adding some modifications to the code and committing them, you need to upd
 
 :: 
 
-    docker run -it --rm -v /Users/famille/Desktop/analyzeG3/projects:/usr/src/exakat/projects exakat/exakat:dev exakat update -p sculpin 
-    docker run -it --rm -v /Users/famille/Desktop/analyzeG3/projects:/usr/src/exakat/projects exakat/exakat:dev exakat project -p sculpin
+    docker run -it --rm -v /Users/famille/Desktop/analyzeG3/projects:/usr/src/exakat/projects exakat/exakat:latest update -p sculpin 
+    docker run -it --rm -v /Users/famille/Desktop/analyzeG3/projects:/usr/src/exakat/projects exakat/exakat:latest project -p sculpin
 
 
 Docker container, within the code folder
@@ -124,7 +124,7 @@ After creating the configuration file, an audit may be run from the same directo
 
 :: 
 
-    docker run -it --rm -v $(`pwd`):/src exakat/exakat:latest exakat project
+    docker run -it --rm -w /src -v $(pwd):/src exakat/exakat:latest project
 
 This command runs the whole cycle : code loading, code audits and report building. It works without initial configuration. 
 
@@ -161,5 +161,5 @@ Check the `.exakat.yml` file before running the audit, to check if all the repor
 
 :: 
 
-    docker run -it --rm -w /src -v $(pwd):/src --entrypoint "/usr/src/exakat/exakat.phar" exakat/exakat:latest project
+    docker run -it --rm -w /src -v $(pwd):/src exakat/exakat:latest project
 


### PR DESCRIPTION
Fix a few problems on the Docker docs:

- Inconsistent use of `exakat/exakat:latest` vs `exakat/exakat:dev`, switched them all to `latest`.
- The latest version now has the entrypoint specified, so the `exakat` as the first param now breaks with the error `Unknown command 'exakat'. See https://exakat.readthedocs.io/en/latest/Administrator/Commands.html`, so removing that extra argument fixes that.
- `-w /src` was missing on the "within the code folder" instructions so it didn't work at all, saying there was no project.
- Specifying `--entrypoint` is now redundant.

Arguably, the "run in the same directory" section should be _first_ because it's _much_ easier to use and has less friction. The steps at the top use a random project `sculpin` which is somewhat confusing, it wasn't obvious to me that this was just an example and not some special formula that _must_ be done before running it on your own project ("is sculpin a dependency? hmm...")

Maybe worth mentioning that `.exakat/` should be added to `.gitignore` in the project, because it generates _a lot_ of stuff that should definitely not be committed to the project.